### PR TITLE
Fixes to the bug (Thanks to Screw5145, it contains the changes this user has made)

### DIFF
--- a/FinalDriver.cpp
+++ b/FinalDriver.cpp
@@ -32,22 +32,29 @@ double STARdist;
 int main(){
 
     buildMovieStore();
+    string intfloatSpaceholder;
     int choice = 0;
     cout << "Welcome to SuperDuperMovieRenter!" << endl;
     cout << "In order for us to serve you better, please provide the following information:" << endl;
     cout << "How far away is your nearest Barnes&Noble? (miles) "<< endl;
-    cin >> BNdist;
+    getline(cin, intfloatSpaceholder);
+    BNdist = atof(intfloatSpaceholder.c_str());
     cout << "How far away is your nearest BlockBuster? (miles)" << endl;
-    cin >> BBdist;
+    getline(cin, intfloatSpaceholder);
+    BBdist = atof(intfloatSpaceholder.c_str());
     cout << "How far away is your nearest DVDRental? (miles)" << endl;
-    cin >> DVDdist;
+    getline(cin, intfloatSpaceholder);
+    DVDdist = atof(intfloatSpaceholder.c_str());
     cout << "How far away is your nearest Redbox? (miles)" << endl;
-    cin >> RBdist;
+    getline(cin, intfloatSpaceholder);
+    RBdist = atof(intfloatSpaceholder.c_str());
     cout << "How far away is your nearest STAR? (miles)"<< endl;
-    cin >> STARdist;
+    getline(cin, intfloatSpaceholder);
+    STARdist = atof(intfloatSpaceholder.c_str());
 
     choice = menu(); //initiates the menu
     while (choice != 4){ //as long as the user does not choose to quit
+            cout << "Choice is: " << choice << endl;
             if (choice == 1){ //print inventory of a store
             cout << "Would you like to print the inventory of Barnes&Noble, BlockBuster, DVDRentals, Redbox, or STAR?" << endl;
             string storename;
@@ -77,7 +84,7 @@ int main(){
             cout << "Enter title:" << endl;
             string findtitle;
             getline(cin,findtitle);
-            getline(cin,findtitle);
+            findtitle=RedBox->searchTree(findtitle);
             cout << "The price to rent " << findtitle << " from:" << endl;
             BarnesNoble->findMovie("Barnes&Noble", findtitle);
             BlockBuster->findMovie("BlockBuster", findtitle);
@@ -91,60 +98,51 @@ int main(){
             string rentTitle;
             string rentTransportation;
             double coupon;
-            cout<<"Please enter the name of the store."<<endl;
-            cin>>rentStore;
-            cout<<"Please enter the movie title."<<endl;
-            cin >> rentTitle;
-            cout<<"Please enter your coupon (in dollars). If you do not have a coupon, enter 0"<<endl;
-            cin>>coupon;
-            cout<<"Please enter your method of transportation (Walk, Drive or Bus)."<<endl;
-            cin>>rentTransportation;
-            if (rentTransportation=="Drive"){
-                cout << "What is your car's fuel efficiency? (miles per gallon)" << endl;
-                cin >> efficiency;
-                cout << "How much is gasoline right now? (dollars per gallon)" << endl;
-                cin >> gasprice;
-                if(rentStore == "Barnes&Noble"){
-                    BarnesNoble->rentMovieDrive("Barnes&Noble", BNdist, rentTitle, coupon);
+            cout<<"Please enter the name of the store. (Barnes&Noble, BlockBuster, DVDRentals, RedBox, or STAR)"<<endl;
+            getline(cin, rentStore);
+            if(rentStore=="Barnes&Noble"||rentStore=="BlockBuster"||rentStore=="DVDRentals"||rentStore=="RedBox"||rentStore=="STAR"){
+                cout<<"Please enter the movie title."<<endl;
+                getline(cin,rentTitle);
+                cout<<"Please enter your coupon (in dollars). If you do not have a coupon, enter 0"<<endl;
+                getline(cin, intfloatSpaceholder);
+                coupon= atof(intfloatSpaceholder.c_str());
+                cout<<"Please enter your method of transportation (Walk, Drive or Bus)."<<endl;
+                getline(cin,rentTransportation);
+                if (rentTransportation=="Drive"){
+                    cout << "What is your car's fuel efficiency? (miles per gallon)" << endl;
+                    getline(cin, intfloatSpaceholder);
+                    efficiency = atof(intfloatSpaceholder.c_str());
+                    cout << "How much is gasoline right now? (dollars per gallon)" << endl;
+                    getline(cin, intfloatSpaceholder);
+                    gasprice = atof(intfloatSpaceholder.c_str());
+                    if(rentStore == "Barnes&Noble"){
+                        BarnesNoble->rentMovieDrive("Barnes&Noble", BNdist, rentTitle, coupon);
+                    }else if(rentStore=="BlockBuster"){
+                        BlockBuster->rentMovieDrive("BlockBuster", BBdist, rentTitle, coupon);
+                    }else if(rentStore=="DVDRentals"){
+                        DVDRentals->rentMovieDrive("DVDRentals", DVDdist, rentTitle, coupon);
+                    }else if(rentStore=="RedBox"){
+                        RedBox->rentMovieDrive("Redbox", RBdist, rentTitle, coupon);
+                    }else if(rentStore=="STAR"){
+                        STAR->rentMovieDrive("STAR", STARdist, rentTitle, coupon);
+                    }
                 }
-                if(rentStore=="BlockBuster"){
-                    BlockBuster->rentMovieDrive("BlockBuster", BBdist, rentTitle, coupon);
+                if (rentTransportation=="Bus"){
+                    cout<<"How much is your bus fare?"<<endl;
+                    getline(cin, intfloatSpaceholder);
+                    busFare = atof(intfloatSpaceholder.c_str());
+                    if(rentStore=="Barnes&Noble"){
+                        BarnesNoble->rentMovieBus("Barnes&Noble", busFare, rentTitle, coupon);
+                    }else if(rentStore=="BlockBuster"){
+                        BlockBuster->rentMovieBus("BlockBuster", busFare, rentTitle, coupon);
+                    }else if(rentStore=="DVDRentals"){
+                        DVDRentals->rentMovieBus("DVDRentals", busFare, rentTitle, coupon);
+                    }else if(rentStore=="RedBox"){
+                        RedBox->rentMovieBus("Redbox", busFare, rentTitle, coupon);
+                    }else if(rentStore=="STAR"){
+                        STAR->rentMovieBus("STAR", busFare, rentTitle, coupon);
+                    }
                 }
-                if(rentStore=="DVDRentals"){
-                    DVDRentals->rentMovieDrive("DVDRentals", DVDdist, rentTitle, coupon);
-                }
-                if(rentStore=="RedBox"){
-                    RedBox->rentMovieDrive("Redbox", RBdist, rentTitle, coupon);
-                }
-                if(rentStore=="STAR"){
-                    STAR->rentMovieDrive("STAR", STARdist, rentTitle, coupon);
-                }
-                else{
-                    cout << "Please enter a valid movie store (Barnes&Noble, BlockBuster, DVDRentals, RedBox, or STAR)." << endl;
-                }
-            }
-            if (rentTransportation=="Bus"){
-                cout<<"How much is your bus fare?"<<endl;
-                cin >> busFare;
-                if(rentStore=="Barnes&Noble"){
-                    BarnesNoble->rentMovieBus("Barnes&Noble", busFare, rentTitle, coupon);
-                }
-                if(rentStore=="BlockBuster"){
-                    BlockBuster->rentMovieBus("BlockBuster", busFare, rentTitle, coupon);
-                }
-                if(rentStore=="DVDRentals"){
-                    DVDRentals->rentMovieBus("DVDRentals", busFare, rentTitle, coupon);
-                }
-                if(rentStore=="RedBox"){
-                    RedBox->rentMovieBus("Redbox", busFare, rentTitle, coupon);
-                }
-                if(rentStore=="STAR"){
-                    STAR->rentMovieBus("STAR", busFare, rentTitle, coupon);
-                }
-                else{
-                    cout << "Please enter a valid movie store (Barnes&Noble, BlockBuster, DVDRentals, RedBox, or STAR)." << endl;
-                }
-            }
             if (rentTransportation=="Walk"){
                 if(rentStore=="Barnes&Noble"){
                     BarnesNoble->rentMovieWalk("Barnes&Noble", rentTitle, coupon);
@@ -161,9 +159,10 @@ int main(){
                 if(rentStore=="STAR"){
                     STAR->rentMovieWalk("STAR", rentTitle, coupon);
                 }
-                else{
-                    cout << "Please enter a valid movie store (Barnes&Noble, BlockBuster, DVDRentals, RedBox, or STAR)." << endl;
-                }
+            }
+        }
+        else{
+            cout << "Please enter a valid movie store (Barnes&Noble, BlockBuster, DVDRentals, RedBox, or STAR)." << endl;
             }
         }
        choice = menu(); //brings up the menu again
@@ -182,8 +181,11 @@ int menu() //main menu and decisions
     cout << "4. Quit" << endl;
 
     int choice1;
-    cin >> ws;
-    cin >> choice1;
+    /*cin >> ws;
+    cin >> choice1;*/
+    string rawInput;
+    getline(cin, rawInput);
+    choice1 = atoi(rawInput.c_str());
     return choice1;
 }
 

--- a/MovieTree.cpp
+++ b/MovieTree.cpp
@@ -26,12 +26,12 @@ Function prototype:
 void MovieTree::printMovieInventory(MovieNode *node)
 
 Function description:
-This method uses a binary search tree traversal to print out the movies a store carreis in alphabtical order. 
+This method uses a binary search tree traversal to print out the movies a store carreis in alphabtical order.
 Example:
 BlockBuster->printMovieIncentory(root);
 
-Precondition: Root of MovieTree must exist. MovieTree must be filled out and established. 
-Post condition: MovieTree is unchanged, contents printed out for user. 
+Precondition: Root of MovieTree must exist. MovieTree must be filled out and established.
+Post condition: MovieTree is unchanged, contents printed out for user.
 */
 void MovieTree::printMovieInventory(MovieNode *node){
     if (node->leftChild != NULL){
@@ -48,11 +48,11 @@ Function prototype:
 void MovieTree::addMovieNode(string title, double price)
 
 Function description:
-This method reads in a .txt file to add movies to a store and stores them in a binary search tree.  
+This method reads in a .txt file to add movies to a store and stores them in a binary search tree.
 Example:
 BlockBuster->addMovieNode(title, price);
 
-Precondition: Root of MovieTree must exist. MovieTree must be established. title and price must be read in from .txt file. 
+Precondition: Root of MovieTree must exist. MovieTree must be established. title and price must be read in from .txt file.
 Post condition: adds a movie node to the movie tree.
 */
 void MovieTree::addMovieNode(string title, double price){
@@ -100,16 +100,16 @@ Function prototype:
 MovieNode* MovieTree::searchTree(string storename, MovieNode * node, string title)
 
 Function description:
-Called by findMovie. This method uses a binary search tree traversal to find and return the movie node that corresponds to the title to user desires. 
-If movie is not carried by particular store, will return that the store "currently does not carry" the title. 
+Called by findMovie. This method uses a binary search tree traversal to find and return the movie node that corresponds to the title to user desires.
+If movie is not carried by particular store, will return that the store "currently does not carry" the title.
 Example:
  p = MovieTree::searchTree("BlockBuster", root, "Whiplash");
 
-Precondition: Root of MovieTree must exist. MovieTree must be filled out and established. 
-Post condition: Find the corresponding movieNode with the information for title desired by user. 
+Precondition: Root of MovieTree must exist. MovieTree must be filled out and established.
+Post condition: Find the corresponding movieNode with the information for title desired by user.
 */
 MovieNode* MovieTree::searchTree(string storename, MovieNode * node, string title){
-    if (title == node->title){
+    if(compare(node->title,title)){
         return node;
     }
     else if(title < node->title){
@@ -135,22 +135,22 @@ Function prototype:
 void MovieTree::rentMovieBus(string storename, double busFare, string title, double coupon)
 
 Function description:
-Finds the total price of renting the movie if the user takes the bus. Calls searchTree function to determine if the store carries the title or not. 
+Finds the total price of renting the movie if the user takes the bus. Calls searchTree function to determine if the store carries the title or not.
 
 Example:
 STAR->rentMovieBus("STAR", 2, "The Dark Knight Rises", 0)
 
 Precondition: Root of MovieTree must exist. MovieTree must be filled out and established. Storename must be valid, busFare must be valid, title must be a string, coupon must be a number greater than or equal to 0.
-Post condition: Calculuates how much it would be to rent the movie from a certain store if user rides bus. 
+Post condition: Calculuates how much it would be to rent the movie from a certain store if user rides bus.
 */
 
 void MovieTree::rentMovieBus(string storename, double busFare, string title, double coupon){
     MovieNode *p = new MovieNode();
     double totalprice;
     p = MovieTree::searchTree(storename, root, title);
-        if(p->title == title){
+        if(compare(p->title,title)){
         totalprice = p->price + (2*busFare) - coupon;
-        cout << "The total price to rent " << title << " from " << storename << " by taking the bus is " << fixed << setprecision(2) << totalprice << "." << endl;
+        cout << "The total price to rent " << p->title << " from " << storename << " by taking the bus is " << fixed << setprecision(2) << totalprice << "." << endl;
     }
 }
 
@@ -159,13 +159,13 @@ Function prototype:
 void MovieTree::rentMovieDrive(string storename, double storedist, string title, double coupon)
 
 Function description:
-Finds the total price of renting the movie if the user drives. Asks for fuel efficiency and price of gas. Calls searchTree function to determine if the store carries the title or not. 
+Finds the total price of renting the movie if the user drives. Asks for fuel efficiency and price of gas. Calls searchTree function to determine if the store carries the title or not.
 
 Example:
 STAR->rentMovieDrive("STAR", 2, "Spirited Away", 0)
 
 Precondition: Root of MovieTree must exist. MovieTree must be filled out and established. Storename must be valid, distance must be valid, title must be a string, coupon must be a number greater than or equal to 0. User must have inputted a efficiency and a gas price previously.
-Post condition: Calculuates how much it would be to rent the movie from a certain store if user drives. 
+Post condition: Calculuates how much it would be to rent the movie from a certain store if user drives.
 */
 
 void MovieTree::rentMovieDrive(string storename, double storedist, string title, double coupon){
@@ -173,10 +173,10 @@ void MovieTree::rentMovieDrive(string storename, double storedist, string title,
     double totalprice;
     double rentalprice;
     p = MovieTree::searchTree(storename, root, title);
-        if(p->title == title){
+        if(compare(p->title,title)){
         rentalprice = p->price;
         totalprice = MovieTree::totalMovieCost(storedist, efficiency, gasprice, rentalprice);
-        cout << "The total price to rent " << title << " from " << storename << " by driving is " << fixed << setprecision(2) << totalprice - coupon << "." << endl;
+        cout << "The total price to rent " << p->title << " from " << storename << " by driving is " << fixed << setprecision(2) << totalprice - coupon << "." << endl;
     }
 }
 
@@ -185,22 +185,22 @@ Function prototype:
 void MovieTree::rentMovieWalk(string storename, string title, double coupon)
 
 Function description:
-Finds the total price of renting the movie if the user walks. Calls searchTree function to determine if the store carries the title or not. 
+Finds the total price of renting the movie if the user walks. Calls searchTree function to determine if the store carries the title or not.
 
 Example:
 STAR->rentMovieWalk("STAR","Spirited Away", 0)
 
 Precondition: Root of MovieTree must exist. MovieTree must be filled out and established. Storename must be valid, title must be a string, coupon must be a number greater than or equal to 0.
-Post condition: Calculuates how much it would be to rent the movie from a certain store if user drives. 
+Post condition: Calculuates how much it would be to rent the movie from a certain store if user drives.
 */
 
 void MovieTree::rentMovieWalk(string storename, string title, double coupon){
     MovieNode *p = new MovieNode();
     double totalprice;
     p = MovieTree::searchTree(storename, root, title);
-        if(p->title == title){
+        if(compare(p->title,title)){
         totalprice = p->price - coupon;
-        cout << "The total price to rent " << title << " from " << storename << " by walking is " << fixed << setprecision(2) << totalprice << "." << endl;
+        cout << "The total price to rent " << p->title << " from " << storename << " by walking is " << fixed << setprecision(2) << totalprice << "." << endl;
     }
 }
 
@@ -209,19 +209,19 @@ Function prototype:
 void MovieTree::findMovie(string storename, string title)
 
 Function description:
-Finds movie in tree. Calls searchTree function to determine if the store carries the title or not. 
+Finds movie in tree. Calls searchTree function to determine if the store carries the title or not.
 
 Example:
 BlockBuster->findMovie("BlockBuster","Shawshank Redemption")
 
 Precondition: Root of MovieTree must exist. MovieTree must be filled out and established. Storename must be valid, title must be a string.
-Post condition: Finds movie in tree and outputs movie and price if available. 
+Post condition: Finds movie in tree and outputs movie and price if available.
 */
 void MovieTree::findMovie(string storename, string title){
     MovieNode *p = new MovieNode();
     double totalprice;
     p = MovieTree::searchTree(storename, root, title);
-        if(p->title == title){
+        if(compare(p->title,title)){
         totalprice = p->price;
         cout << "\t" << storename << " is " << fixed << setprecision(2) << totalprice << "." << endl;
     }
@@ -238,7 +238,7 @@ Example:
 totalcost = totalMovieCost(4, 20, 2, 1.40);
 
 Precondition: distance, efficiency, gasprice, and rentalprice must be valid numbers.
-Post condition: Returns total cost of movie if user drives. 
+Post condition: Returns total cost of movie if user drives.
 */
 
 double MovieTree::totalMovieCost(double distance, double efficiency, double gasprice, double rentalprice){
@@ -249,3 +249,86 @@ double MovieTree::totalMovieCost(double distance, double efficiency, double gasp
     return totalprice;
 }
 
+/*
+Function prototype:
+double MovieTree::compare(string one, string two)
+
+Function description:
+Determines if two strings are the same regardless of case
+
+Example:
+bool same = compare(title, movie->title);
+
+Precondition: string being compared and string of title in the node
+Post condition: Returns true if the movies are the same and false if not
+*/
+
+bool MovieTree::compare(std::string one, std::string two){
+    int same=0;
+    if(one.length()==two.length()){
+        for(int i=0; i<one.length(); i++){
+            if(one[i]==two[i] || (one[i]+32)==two[i] || (two[i]+32)==one[i]){
+                    same++;
+            }
+            else{
+                return false;
+            }
+        }
+        if(same==one.length()){
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
+Function prototype:
+string MovieTree::searchTree(string title)
+
+Function description:
+Determines if movie is in the library already, so that it will print out the appropriate case of title
+
+Example:
+string title = RedBox->searchTree(title);
+
+Precondition: string that is returned is the original string if the movie was not found (just as the original function did)
+but if it was found, it will change the title to the appropriate capitalization of the word. this calls the recursive.
+*/
+string MovieTree::searchTree(string title){
+    MovieNode *temp;
+    temp = searchTree(root,title);
+    if(temp==NULL){
+        return title;
+    }
+    else{
+        return temp->title;
+    }
+}
+
+/*
+Function prototype:
+string MovieTree::searchTree(MovieNode *node, string title)
+
+Function description:
+Determines if movie is in the library already, so that it will print out the appropriate case of title
+
+Example:
+MovieNode *node = searchTree(node, title)
+
+Precondition: will return the node of the movie if it was found, will return null if not found. this is used to cout the
+real title of the movie
+*/
+MovieNode* MovieTree::searchTree(MovieNode * node, string title){
+    if(node==NULL){
+        return NULL;
+    }
+    else if(compare(node->title,title)){
+        return node;
+    }
+    else if(title < node->title){
+        return(searchTree(node->leftChild, title));
+    }
+    else if(title > node->title){
+        return(searchTree(node->rightChild, title));
+    }
+}

--- a/MovieTree.cpp
+++ b/MovieTree.cpp
@@ -267,8 +267,18 @@ bool MovieTree::compare(std::string one, std::string two){
     int same=0;
     if(one.length()==two.length()){
         for(int i=0; i<one.length(); i++){
-            if(one[i]==two[i] || (one[i]+32)==two[i] || (two[i]+32)==one[i]){
+            if(one[i]==two[i]){
                     same++;
+            }
+            else if(one[i]>=65 && one[i]<=90){
+                if(one[i]+32==two[i]){
+                    same++;
+                }
+            }
+            else if(two[i]>=65 && two[i]<=90){
+                if(two[i]+32==one[i]){
+                    same++;
+                }
             }
             else{
                 return false;

--- a/MovieTree.h
+++ b/MovieTree.h
@@ -40,6 +40,9 @@ class MovieTree
         void rentMovieDrive(string storename, double storedist, string title, double coupon);
         void rentMovieWalk(string storename, string title, double coupon);
         void rentMovieBus(string storename, double busFare, string title, double coupon);
+        bool compare(std::string one, std::string two);
+        string searchTree(string title);
+        MovieNode* searchTree(MovieNode * node, string title);
         double totalMovieCost(double distance, double efficiency, double gasprice, double rentalprice);
     protected:
     private:


### PR DESCRIPTION
as well as my own additions: added a contribution where the case of the movie does not have to match exactly, I copied the fix of Screw5145 so I could use the code all the way and keep the change the same. I also reorderd the invalid store part. It will tell you an invalid store has been entered before you enter all of the information.

For example:
If the user types in: "the matrix"
The program will understand it is "The Matrix" and will refer to the movie in its correct capitalization.

Also, if the user types in "star" in the rent part, the program will immediately say "invalid store" off the bat, instead of entering the rest of the information and then having the program tell the user the store is invalid. 

I like the program though! It was enjoyabe seeing how it worked and I liked how it determined the total cost based on gas and stuff like that.
